### PR TITLE
add a hidden warning when the homepage webroot is incorrect

### DIFF
--- a/lucee/tomcat9/tomcat-lucee-conf/webapps/ROOT/assets/css/core/_ed07b761.core.min.css
+++ b/lucee/tomcat9/tomcat-lucee-conf/webapps/ROOT/assets/css/core/_ed07b761.core.min.css
@@ -13,3 +13,4 @@ html{-webkit-text-size-adjust:none}body{font-family:'Open Sans',Arial,sans-serif
 	display:inline-block;text-indent:-999em;
 	vertical-align:middle;margin-right:10px}
 .widget-text p.readmore{font-weight:700;font-size:12px;line-height:1.2}
+.wrong-mapping-warning { display:none }

--- a/lucee/tomcat9/tomcat-lucee-conf/webapps/ROOT/index.cfm
+++ b/lucee/tomcat9/tomcat-lucee-conf/webapps/ROOT/index.cfm
@@ -43,8 +43,13 @@
                         </div>
                 </div>
         </section>
-
-
+        
+        <cfoutput>
+                <section id="wrong-mapping-warning" class="wrong-mapping-warning" style="text-align: center; font-weight: bolder; color: red; border: red 2px solid; margin:15px; padding: 5px;">
+                        <p>Warning, if you can see this message, your webserver webroot is not mapped to [#getDirectoryFromPath(getCurrentTemplatePath())#].</p>
+                        <p>This means Lucee is only configured to handle .cfm and .cfc and other files like css, js and images won't load properly</p>
+                </section>
+        </cfoutput>
 
         <section id="contents">
 


### PR DESCRIPTION
add a normally hidden by css warning message, when css , js and image files can't load due to a incorrect webroot mapping

![image](https://user-images.githubusercontent.com/426404/125769771-aa289546-30c6-4d6d-8783-6dc3d0c0f02b.png)
