### PR TITLE
make copyright year on front page dynamic

### DIFF
--- a/lucee/tomcat9/tomcat-lucee-conf/webapps/ROOT/index.cfm
+++ b/lucee/tomcat9/tomcat-lucee-conf/webapps/ROOT/index.cfm
@@ -241,7 +241,7 @@
 		                    
 
 		                    <div class="col-md-5 col-sm-4">
-		                        <p class="copyright-text">Copyright &copy; 2015 by the Lucee Association Switzerland</p>
+		                        <p class="copyright-text">Copyright &copy; <cfoutput>#year(now())#</cfoutput> by the Lucee Association Switzerland</p>
 		                    </div>
 		                    
 


### PR DESCRIPTION
It was hard-coded as 2015, but should seemingly always be the current year. (This is how US copyright law works. Perhaps it's different in Switzerland, in which case I'll understand if you reject this PR.)