### PR TITLE
fix build.sh line 42 missing closing double-quote

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -39,7 +39,7 @@ ls -laht /tmp/ib/output/
 /tmp/ib/output/lucee-${LUCEE_VERSION}-linux-x64-installer.run --version
 
 out=`/tmp/ib/output/lucee-${LUCEE_VERSION}-linux-x64-installer.run --version`
-tet="Lucee $LUCEE_VERSION
+tet="Lucee $LUCEE_VERSION"
 if [[ $out != $tet* ]]
 then
 	echo Incorrect version banner


### PR DESCRIPTION
The missing double-quote doesn't throw error because bash auto-closes the variable declaration at EOF, but it prevents warning re: Incorrect version banner (and exit 1) at end of build.sh.