### PR TITLE
docs: edit lucee_ctl_changelog.md item #8

### DIFF
--- a/lucee/linux/sys/lucee_ctl_changelog.md
+++ b/lucee/linux/sys/lucee_ctl_changelog.md
@@ -1,0 +1,27 @@
+# lucee_ctl changelog
+
+## 2025-08-03
+
+1. Performance optimizations: restart is faster because it doesn't arbitrarily wait 5 seconds when the server may have stopped much quicker than that; startup confirmation exits immediately upon success instead of waiting fixed time; stop is faster due to refactoring of redundant findpid calls; proactive stale PID cleanup prevents unnecessary process check.
+
+2. Replaced `findpid()` with the more semantically correct `checkisrunning()`, which first deletes stale PID file from server reboot.
+
+3. `start()` function now confirms whether the server is running (with 10 second timeout) and provides proper success/failure feedback instead of just assuming it worked.
+
+4. `stop()` function now waits for graceful shutdown and provides better timeout messaging when forcing a kill.
+
+5. `status()` function enhanced to show not just the PID but also "has been running since" datetime.
+
+6. Added a proper `restart()` function that waits for confirmation of shutdown before starting again, replacing the old "stop, sleep 5, start" approach.
+
+7. Improved error handling and user feedback throughout with more descriptive messages and exit status checking.
+
+8. Removed support for environments that don't have JRE installed because it is bundled with Lucee installer.
+
+9. Removed support for OpenBD while remaining backward compatible with legacy automated workflows as long as the engine argument is set to "lucee".
+
+10. Refactored if statements to use [[ ... ]] (bash conditional) instead of [ ... ] (POSIX) and double quotes around variables to prevent word splitting and globbing.
+
+11. Improved Usage statement by removing brackets around username argument because it is not optional.
+
+12. Changed `rm -rf` to `rm -f` because -r (recursive) applies only to directories.

--- a/lucee/linux/sys/lucee_ctl_changelog.md
+++ b/lucee/linux/sys/lucee_ctl_changelog.md
@@ -16,7 +16,7 @@
 
 7. Improved error handling and user feedback throughout with more descriptive messages and exit status checking.
 
-8. Removed support for environments that don't have JRE installed because it is bundled with Lucee installer.
+8. Removed support for environments that don't have JRE installed because it is bundled with Lucee installer. That resulted in removal of substitution patterns `@@luceeJREhome@@` and `@@luceeJAVAhome@@` in lucee.xml which means change_user.sh can be tested independently of building the installer.
 
 9. Removed support for OpenBD while remaining backward compatible with legacy automated workflows as long as the engine argument is set to "lucee".
 

--- a/lucee/linux/sys/lucee_ctl_template
+++ b/lucee/linux/sys/lucee_ctl_template
@@ -1,6 +1,6 @@
 #!/bin/bash
 # chkconfig: 345 22 78
-# description: Tomcat/${myCFServerName} Control Script
+# description: Tomcat/Lucee Control Script
 
 ### BEGIN INIT INFO
 # Provides:          lucee_ctl
@@ -21,52 +21,67 @@ CATALINA_BASE=${myInstallDir}/tomcat; export CATALINA_BASE
 CATALINA_HOME=${myInstallDir}/tomcat; export CATALINA_HOME
 CATALINA_PID=${myInstallDir}/tomcat/work/tomcat.pid; export CATALINA_PID
 CATALINA_TMPDIR=${myInstallDir}/tomcat/temp; export CATALINA_TMPDIR
-@@luceeJREhome@@
-@@luceeJAVAhome@@
+JRE_HOME=${myInstallDir}/jre; export JRE_HOME
+JAVA_HOME=${myInstallDir}/jre; export JAVA_HOME
 TOMCAT_OWNER=${myUserName}; export TOMCAT_OWNER
 
-findpid() {
-	PID_FOUND=0
+checkisrunning() {
+	LUCEE_IS_RUNNING=0
+	# delete stale PID caused by server reboot
+	if [[ -f "$CATALINA_PID" && /proc -nt "$CATALINA_PID" ]]; then
+		rm "$CATALINA_PID"
+	fi
 	if [ -f "$CATALINA_PID" ] ; then
 		PIDNUMBER=`cat "$CATALINA_PID"`
 		TEST_RUNNING=`ps -p ${PIDNUMBER} | grep ${PIDNUMBER} | grep java`
 		if [ ! -z "${TEST_RUNNING}" ]; then 
 			# PID is found and running
-			PID_FOUND=1
+			LUCEE_IS_RUNNING=1
 		fi
 	fi
 }
 
 start() {
-	echo -n " * Starting ${myCFServerName}: "
-	findpid
-	# only actually run the start command if the PID isn't found
-	if [ $PID_FOUND -eq 0 ] ; then
+	echo " * Starting Lucee: "
+	checkisrunning
+	if [ $LUCEE_IS_RUNNING -eq 0 ] ; then
 		su -p -s /bin/sh $TOMCAT_OWNER $CATALINA_HOME/bin/startup.sh
+		echo -n " * Waiting for confirmation that Lucee is running: "
 		COUNT=0
-		while [ $COUNT -lt 3 ] ; do
+		while [ $LUCEE_IS_RUNNING -eq 0 ] ; do
 			COUNT=$((${COUNT}+1))
+			if [ $COUNT -gt 10 ] ; then
+				break
+			fi
 			echo -n ". "
 			sleep 1
+			checkisrunning
 		done
-		echo "[DONE]"
-		echo "--------------------------------------------------------"
-		echo "It may take a few moments for ${myCFServerName} to start processing"
-		echo "CFML templates. This is normal."
-		echo "--------------------------------------------------------"
+		if [ $LUCEE_IS_RUNNING -eq 1 ] ; then
+			echo "[DONE]"
+			echo ""
+			echo "--------------------------------------------"
+			echo "It may take a few seconds for Lucee to start"
+			echo "responding to requests. This is normal."
+			echo "--------------------------------------------"
+		else
+			echo "[TIMED OUT WITH STATUS UNKNOWN]"
+			echo "-------------------------------------------------------------"
+			echo "WARNING: Lucee may not be running. Be sure to test your apps!"
+			echo "-------------------------------------------------------------"
+		fi
 	else
 		echo "[ALREADY RUNNING]"
 	fi
 }
 
 stop() {
-	echo -n " * Shutting down ${myCFServerName}: "
-	findpid
-	if [ $PID_FOUND -eq 1 ] ; then
+	echo -n " * Shutting down Lucee: "
+	checkisrunning
+	if [ $LUCEE_IS_RUNNING -eq 1 ] ; then
 		su -p -s /bin/sh $TOMCAT_OWNER $CATALINA_HOME/bin/shutdown.sh &> /dev/null &
 		COUNT=0
-		while [ $PID_FOUND -eq 1 ] ; do
-			findpid
+		while [ $LUCEE_IS_RUNNING -eq 1 ] ; do
 			COUNT=$((${COUNT}+1))
 			if [ $COUNT -gt 20 ] ; then
 				break
@@ -74,16 +89,16 @@ stop() {
 			echo -n ". "
 			# pause while we wait to try again
 			sleep 1
+			checkisrunning
 		done
-		findpid
-		if [ $PID_FOUND -eq 1 ] ; then
-			echo "[FAIL]"
-			echo " * The Tomcat/${myCFServerName} process is not responding. Forcing shutdown..."
+		if [ $LUCEE_IS_RUNNING -eq 1 ] ; then
+			echo "[TIMED OUT]"
+			echo " * Tomcat/Lucee graceful stop timed out. Forcing shutdown..."
 			forcequit
 		else
 			echo "[DONE]"
 		fi
-	elif [ ! -f $CATALINA_PID ] ; then
+	elif [ ! -f "$CATALINA_PID" ] ; then
 		# if the pid file doesn't exist, just say "okay"
 		echo "[DONE]"
 	else
@@ -97,13 +112,13 @@ stop() {
 }
 
 forcequit() {
-	echo -n " * Forcing ${myCFServerName} Shutdown: "
-	findpid
-	if [ $PID_FOUND -eq 1 ] ; then
+	echo -n " * Forcing Lucee Shutdown: "
+	checkisrunning
+	if [ $LUCEE_IS_RUNNING -eq 1 ] ; then
 		# if the PID is still running, force it to die
 		# su -p -s /bin/sh $TOMCAT_OWNER $CATALINA_HOME/bin/shutdown.sh -force
 		kill -9 $PIDNUMBER
-		rm -rf $CATALINA_PID
+		rm -f "$CATALINA_PID"
 		echo "[DONE]"
 	else
 		# there is no PID, tell the user.
@@ -116,12 +131,39 @@ forcequit() {
 }
 
 status() {
-	findpid
-	if [ $PID_FOUND -eq 1 ] ; then
-		echo " * ${myCFServerName}/Tomcat is running (PID: $PIDNUMBER)"
+	checkisrunning
+	if [ $LUCEE_IS_RUNNING -eq 1 ] ; then
+		PIDTIME=`ls -l "$CATALINA_PID" | awk '{print $6, $7, $8}'`
+		echo " * Lucee/Tomcat (PID: $PIDNUMBER) is running and has been since $PIDTIME."
 	else
 		echo " * PID not found."
 	fi
+}
+
+restart() {
+	stop
+	# wait up to 5 seconds for confirmation that Lucee has stopped
+	checkisrunning
+	if [ $LUCEE_IS_RUNNING -eq 1 ] ; then
+		echo -n " * Waiting up to 5 seconds for confirmation that Lucee has stopped: "
+		COUNT=0
+		while [ $LUCEE_IS_RUNNING -eq 1 ] ; do
+			echo -n ". "
+			COUNT=$(($COUNT+1))
+			if [ $COUNT -ge 5 ] ; then
+				break
+			fi
+			sleep 1
+			checkisrunning
+		done
+		if [ $LUCEE_IS_RUNNING -eq 1 ] ; then
+			echo "[FAIL]"
+			echo "Lucee may not have stopped properly. Check sites after Lucee restart!"
+		else
+			echo "[DONE]"
+		fi
+	fi
+	start
 }
 
 case "$1" in
@@ -135,9 +177,7 @@ case "$1" in
 		forcequit
 		;;
   restart)
-		stop
-		sleep 5
-		start
+		restart
 		;;
   status)
 		status

--- a/lucee/lucee.xml
+++ b/lucee/lucee.xml
@@ -203,49 +203,10 @@
                 </actionGroup>
                 <dirName path="${java_executable}" variable="java_bin_dir"/>
                 <dirName path="${java_bin_dir}" variable="java_home_dir"/>
-                <substitute>
-                    <files>${installdir}/sys/engine_ctl_template</files>
-                    <type>exact</type>
-                    <ruleList>
-                        <platformTest>
-                            <type>linux</type>
-                        </platformTest>
-                    </ruleList>
-                    <substitutionList>
-                        <substitution>
-                            <pattern>@@luceeJREhome@@</pattern>
-                            <value>JRE_HOME=${installDir}/jre; export JRE_HOME</value>
-                            <ruleList>
-                                <isTrue value="${installjre}"/>
-                            </ruleList>
-                        </substitution>
-                        <substitution>
-                            <pattern>@@luceeJAVAhome@@</pattern>
-                            <value>JAVA_HOME=${installDir}/jre; export JAVA_HOME</value>
-                            <ruleList>
-                                <isTrue value="${installjre}"/>
-                            </ruleList>
-                        </substitution>
-                        <substitution>
-                            <pattern>@@luceeJREhome@@</pattern>
-                            <value>JRE_HOME=${java_home_dir}; export JRE_HOME</value>
-                            <ruleList>
-                                <isFalse value="${installjre}"/>
-                            </ruleList>
-                        </substitution>
-                        <substitution>
-                            <pattern>@@luceeJAVAhome@@</pattern>
-                            <value>JAVA_HOME=${java_home_dir}; export JAVA_HOME</value>
-                            <ruleList>
-                                <isFalse value="${installjre}"/>
-                            </ruleList>
-                        </substitution>
-                    </substitutionList>
-                </substitute>
                 <runProgram>
                     <explanation>${msg(postInstall.updatingTomcatUser)}</explanation>
                     <program>${installdir}/sys/change_user.sh</program>
-                    <programArguments>${systemuser} ${installdir} lucee nobackup</programArguments>
+                    <programArguments>${systemuser} ${installdir} nobackup</programArguments>
                     <progressText>${msg(postInstall.updatingTomcatUser)}</progressText>
                     <useMSDOSPath>0</useMSDOSPath>
                     <ruleList>
@@ -466,53 +427,6 @@
                     <actionList>
                         <dirName path="${java_executable}" variable="java_bin_dir"/>
                         <dirName path="${java_bin_dir}" variable="java_home_dir"/>
-                        <substitute>
-                            <encoding>utf-8</encoding>
-                            <files>${installdir}\tomcat\bin\service.bat</files>
-                            <type>exact</type>
-                            <substitutionList>
-                                <substitution>
-                                    <pattern>@@luceeJREhome@@</pattern>
-                                    <value>set "JRE_HOME=${installdir}\jre"</value>
-                                    <ruleList>
-                                        <isTrue value="${installjre}"/>
-                                    </ruleList>
-                                </substitution>
-                                <substitution>
-                                    <pattern>@@luceeJREhome@@</pattern>
-                                    <value>set "JRE_HOME=${java_home_dir}"</value>
-                                    <ruleList>
-                                        <isFalse value="${installjre}"/>
-                                    </ruleList>
-                                </substitution>
-                                <substitution>
-                                    <pattern>@@startatboot@@</pattern>
-                                    <value>manual</value>
-                                    <ruleList>
-                                        <isFalse>
-                                            <value>${startatboot}</value>
-                                        </isFalse>
-                                    </ruleList>
-                                </substitution>
-                                <substitution>
-                                    <pattern>@@startatboot@@</pattern>
-                                    <value>auto</value>
-                                    <ruleList>
-                                        <isTrue>
-                                            <value>${startatboot}</value>
-                                        </isTrue>
-                                    </ruleList>
-                                </substitution>
-                                <substitution>
-                                    <pattern>@@minheap@@</pattern>
-                                    <value>${minheap}</value>
-                                </substitution>
-                                <substitution>
-                                    <pattern>@@maxheap@@</pattern>
-                                    <value>${maxheap}</value>
-                                </substitution>
-                            </substitutionList>
-                        </substitute>
                         <actionGroup>
                             <actionList>
                                 <copyFile>


### PR DESCRIPTION
I came to realize the significance of the lucee.xml edit's beneficial impact for testing change_user.sh!

8. Removed support for environments that don't have JRE installed because it is bundled with Lucee installer. That resulted in removal of substitution patterns `@@luceeJREhome@@` and `@@luceeJAVAhome@@` in lucee.xml which means change_user.sh can be tested independently of building the installer.