### PR TITLE
LDEV-6164 register BonCode event source to prevent midnight crash

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -596,11 +596,11 @@ jobs:
         if: ${{ matrix.installiis }}
         shell: powershell
         run: |
-          $source = "BonCodeConnector"
-          if ([System.Diagnostics.EventLog]::SourceExists($source)) {
-            Write-Host "PASS: Event source '$source' is registered"
+          $regPath = "HKLM:\SYSTEM\CurrentControlSet\Services\EventLog\Application\BonCodeConnector"
+          if (Test-Path $regPath) {
+            Write-Host "PASS: Event source registry key exists at $regPath"
           } else {
-            Write-Error "FAIL: Event source '$source' is NOT registered"
+            Write-Error "FAIL: Event source registry key NOT found at $regPath"
             exit 1
           }
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -567,7 +567,7 @@ jobs:
         if: ${{ matrix.installiis }}
         shell: powershell
         run: |
-          Install-WindowsFeature -Name Web-Server -IncludeAllSubFeature -IncludeManagementTools
+          Install-WindowsFeature -Name Web-Server
           Start-Service W3SVC
           Write-Host "IIS installed and running"
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -533,6 +533,10 @@ jobs:
   test-windows:
     runs-on: windows-latest
     needs: build-installers
+    strategy:
+      max-parallel: 1
+      matrix:
+        installiis: [ false, true ]
     steps:
       - name: Set defaults for Push workflows
         if: github.event_name == 'push'
@@ -559,12 +563,20 @@ jobs:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Run Windows Installer
+      - name: Install IIS
+        if: ${{ matrix.installiis }}
+        shell: powershell
+        run: |
+          Install-WindowsFeature -Name Web-Server -IncludeAllSubFeature -IncludeManagementTools
+          Start-Service W3SVC
+          Write-Host "IIS installed and running"
+
+      - name: Run Windows Installer [installiis=${{ matrix.installiis }}]
         shell: cmd
         run: |
           cd
-          echo "Lucee Windows installer ${{ env.LUCEE_INSTALLER_VERSION }}" >> %GITHUB_STEP_SUMMARY%
-          lucee-${{ env.LUCEE_INSTALLER_VERSION }}-windows-x64-installer.exe --mode unattended --installconn false --installmodcfml false --installiis false --startatboot true --luceepass ibtest --installjre ${{ env.INSTALL_JRE }}
+          echo "Lucee Windows installer ${{ env.LUCEE_INSTALLER_VERSION }} (installiis=${{ matrix.installiis }})" >> %GITHUB_STEP_SUMMARY%
+          lucee-${{ env.LUCEE_INSTALLER_VERSION }}-windows-x64-installer.exe --mode unattended --installconn false --installmodcfml false --installiis ${{ matrix.installiis }} --startatboot true --luceepass ibtest --installjre ${{ env.INSTALL_JRE }}
           pwd
           c:
           cd c:\lucee\tomcat\bin
@@ -575,10 +587,30 @@ jobs:
           cd ..\..
           pwd
 
-          echo "<cfscript>if (server.lucee.version neq url.version) header statusCode=500;</cfscript><cfoutput>#chr(10)##### Lucee Linux #server.lucee.version#, using Java #server.java.version##chr(10)# #### Running on #server.servlet.name#, OS #server.os.version# #server.os.arch#</cfoutput>" > c:\lucee\tomcat\webapps\ROOT\check.cfm
+          echo "<cfscript>if (server.lucee.version neq url.version) header statusCode=500;</cfscript><cfoutput>#chr(10)##### Lucee Windows #server.lucee.version#, using Java #server.java.version##chr(10)# #### Running on #server.servlet.name#, OS #server.os.version# #server.os.arch#</cfoutput>" > c:\lucee\tomcat\webapps\ROOT\check.cfm
 
           dir c:\lucee\tomcat\webapps\ROOT
           curl http://127.0.0.1:8888/check.cfm?version=${{ env.LUCEE_INSTALLER_VERSION }} --fail-with-body -o %GITHUB_STEP_SUMMARY%
+
+      - name: Verify BonCode event source registered (LDEV-6164)
+        if: ${{ matrix.installiis }}
+        shell: powershell
+        run: |
+          $source = "BonCodeConnector"
+          if ([System.Diagnostics.EventLog]::SourceExists($source)) {
+            Write-Host "PASS: Event source '$source' is registered"
+          } else {
+            Write-Error "FAIL: Event source '$source' is NOT registered"
+            exit 1
+          }
+
+      - name: Verify IIS serves Lucee via Boncode
+        if: ${{ matrix.installiis }}
+        shell: cmd
+        run: |
+          echo "Check IIS port 80 via Boncode" >> %GITHUB_STEP_SUMMARY%
+          curl http://127.0.0.1/check.cfm?version=${{ env.LUCEE_INSTALLER_VERSION }} --fail-with-body >> %GITHUB_STEP_SUMMARY%
+
       - name: debug failure
         if: ${{ failure() }}
         shell: cmd

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ jre/x64-linux/jre/
 jre/aarch64-linux/jre/
 src-tomcat/
 express.bat
+/.claude

--- a/lucee/lucee.xml
+++ b/lucee/lucee.xml
@@ -622,8 +622,8 @@ Please review ${installer_installation_log}.</text>
                              See https://github.com/Bilal-S/iis2tomcat/issues/113 -->
                         <runProgram>
                             <abortOnError>0</abortOnError>
-                            <program>powershell</program>
-                            <programArguments>-Command &quot;New-EventLog -LogName Application -Source 'BonCodeConnector'&quot;</programArguments>
+                            <program>reg</program>
+                            <programArguments>add HKLM\SYSTEM\CurrentControlSet\Services\EventLog\Application\BonCodeConnector /f</programArguments>
                             <ruleList>
                                 <isTrue>
                                     <value>${installiis}</value>

--- a/lucee/lucee.xml
+++ b/lucee/lucee.xml
@@ -618,6 +618,18 @@ Please review ${installer_installation_log}.</text>
                                 </isTrue>
                             </ruleList>
                         </runProgram>
+                        <!-- LDEV-6164: Register BonCode event source to prevent midnight crash
+                             See https://github.com/Bilal-S/iis2tomcat/issues/113 -->
+                        <runProgram>
+                            <abortOnError>0</abortOnError>
+                            <program>powershell</program>
+                            <programArguments>-Command "New-EventLog -LogName Application -Source 'BonCodeConnector' -ErrorAction SilentlyContinue"</programArguments>
+                            <ruleList>
+                                <isTrue>
+                                    <value>${installiis}</value>
+                                </isTrue>
+                            </ruleList>
+                        </runProgram>
                         <copyFile>
                             <destination>${env(SYSTEMDRIVE)}\inetpub\wwwroot\index.cfm</destination>
                             <origin>${installdir}\tomcat\webapps\ROOT\index.cfm</origin>

--- a/lucee/lucee.xml
+++ b/lucee/lucee.xml
@@ -623,7 +623,7 @@ Please review ${installer_installation_log}.</text>
                         <runProgram>
                             <abortOnError>0</abortOnError>
                             <program>powershell</program>
-                            <programArguments>-Command "New-EventLog -LogName Application -Source 'BonCodeConnector'"</programArguments>
+                            <programArguments>-Command &quot;New-EventLog -LogName Application -Source 'BonCodeConnector'&quot;</programArguments>
                             <ruleList>
                                 <isTrue>
                                     <value>${installiis}</value>

--- a/lucee/lucee.xml
+++ b/lucee/lucee.xml
@@ -623,8 +623,7 @@ Please review ${installer_installation_log}.</text>
                         <runProgram>
                             <abortOnError>0</abortOnError>
                             <program>powershell</program>
-                            <programArguments>-Command "New-EventLog -LogName Application -Source 'BonCodeConnector' -ErrorAction SilentlyContinue"</programArguments>
-                            <runAs>Administrator</runAs>
+                            <programArguments>-Command "New-EventLog -LogName Application -Source 'BonCodeConnector'"</programArguments>
                             <ruleList>
                                 <isTrue>
                                     <value>${installiis}</value>

--- a/lucee/lucee.xml
+++ b/lucee/lucee.xml
@@ -624,6 +624,7 @@ Please review ${installer_installation_log}.</text>
                             <abortOnError>0</abortOnError>
                             <program>powershell</program>
                             <programArguments>-Command "New-EventLog -LogName Application -Source 'BonCodeConnector' -ErrorAction SilentlyContinue"</programArguments>
+                            <runAs>Administrator</runAs>
                             <ruleList>
                                 <isTrue>
                                     <value>${installiis}</value>


### PR DESCRIPTION
## Summary

Boncode AJP connector crashes at exactly midnight when logging is enabled and the Windows Event Log source "BonCodeConnector" is not registered. The crash leaves IIS unresponsive until the app pool is restarted.

- Register `BonCodeConnector` event source via `New-EventLog` after Boncode connector install
- Add `installiis` matrix flag to Windows CI (`false` and `true`) so we test both with and without IIS
- IIS test verifies event source registration and that Lucee is served via Boncode on port 80

### Root cause

Every midnight, Boncode reinitialises and logs its version string. `EventLog.SourceExists()` throws because the IIS worker process can't search the Security/State event logs. The exception bubbles into `ConnectionError()` which hits a null ref on `p_NetworkStream` (never assigned). Boncode enters a broken state permanently.

### References

- [LDEV-6164](https://luceeserver.atlassian.net/browse/LDEV-6164)
- [iis2tomcat #113](https://github.com/Bilal-S/iis2tomcat/issues/113)
- [Lucee forum thread](https://dev.lucee.org/t/lucee-6-boncode-connection-problems/17145)

## Test plan

- [ ] `test-windows (installiis: false)` passes (existing behaviour unchanged)
- [ ] `test-windows (installiis: true)` passes (IIS installed, Boncode configured, event source registered)
- [ ] Event source verification step confirms `BonCodeConnector` is registered
- [ ] IIS serves Lucee via Boncode on port 80

[LDEV-6164]: https://luceeserver.atlassian.net/browse/LDEV-6164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ